### PR TITLE
Add charts API to SDK

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { DeviceFlowParams } from "navigraph/auth";
 import { useState } from "react";
 import { useNavigraphAuth } from "src/hooks/useNavigraphAuth";
 import { weather } from "../lib/navigraph";
+import { requestChartsIndex } from "navigraph/charts";
 
 export default function LoginScreen() {
   const [params, setParams] = useState<DeviceFlowParams | null>(null);
@@ -10,6 +11,8 @@ export default function LoginScreen() {
   const { user, isInitialized, signin } = useNavigraphAuth();
 
   const fetchMetar = () => weather.getMetar({ icao: "KJFK" }).then(({ metar }) => setData(metar.rawText));
+
+  const fetchChartsIndex = () => requestChartsIndex("KJFK").then(console.log);
 
   const handleSignIn = () => signin((p) => setParams(p)).catch(() => setParams(null));
 
@@ -42,6 +45,12 @@ export default function LoginScreen() {
           </h2>
           <button onClick={fetchMetar} className="bg-white text-black py-2 px-4 font-semibold rounded-md">
             Fetch METAR report
+          </button>
+          <button
+            onClick={fetchChartsIndex}
+            className="bg-white text-black py-2 px-4 font-semibold rounded-md"
+          >
+            Fetch charts index
           </button>
         </>
       )}

--- a/packages/charts/src/api.ts
+++ b/packages/charts/src/api.ts
@@ -1,0 +1,17 @@
+import { authenticatedAxios } from "auth";
+import { CHARTS_API_ROOT } from "./constants";
+import { Chart, ChartsIndexResponse } from "./public-types";
+
+export const requestChartsIndex = async (icao: string): Promise<ChartsIndexResponse["charts"]> => {
+  const result = await authenticatedAxios.get<ChartsIndexResponse>(`${CHARTS_API_ROOT}/charts/${icao}`);
+  return result.data.charts;
+};
+
+export const requestChartImage = async (chart: Chart, dayMode = true): Promise<Blob> => {
+  const imageUrl = dayMode ? chart.image_day_url : chart.image_night_url;
+  const result = await authenticatedAxios.get<Blob>(imageUrl, {
+    responseType: "blob",
+  });
+  // eslint-disable-next-line no-undef
+  return new File([result.data], chart + ".png");
+};

--- a/packages/charts/src/constants.ts
+++ b/packages/charts/src/constants.ts
@@ -1,0 +1,1 @@
+export const CHARTS_API_ROOT = "https://charts.api-v2.navigraph.com";

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,3 +1,2 @@
-import { authenticatedAxios } from "auth";
-
-// TODO: Implement charts-api
+export * from "./api";
+export * from "./public-types";

--- a/packages/charts/src/public-types.ts
+++ b/packages/charts/src/public-types.ts
@@ -1,0 +1,55 @@
+export interface Pixels {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface Latlng {
+  lng1: number;
+  lat1: number;
+  lng2: number;
+  lat2: number;
+}
+
+export interface Planview {
+  pixels: Pixels;
+  latlng: Latlng;
+}
+
+export interface Inset {
+  pixels: Pixels;
+}
+
+export interface BoundingBoxes {
+  planview: Planview;
+  insets: Inset[];
+}
+
+export interface Chart {
+  image_day: string;
+  image_night: string;
+  thumb_day: string;
+  thumb_night: string;
+  icao_airport_identifier: string;
+  id: string;
+  category: string;
+  precision_approach?: boolean;
+  index_number: string;
+  name: string;
+  revision_date: string;
+  is_georeferenced: boolean;
+  width: number;
+  height: number;
+  bounding_boxes: BoundingBoxes;
+  procedures: string[];
+  runways: string[];
+  image_day_url: string;
+  image_night_url: string;
+  thumb_day_url: string;
+  thumb_night_url: string;
+}
+
+export interface ChartsIndexResponse {
+  charts: Chart[];
+}

--- a/packages/charts/tsconfig.json
+++ b/packages/charts/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2015"],
+    "lib": ["es2015", "dom"],
     "module": "CommonJS",
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
This PR adds the ability to fetch chart indexes for airports as well as chart PNGs through the SDK.