### PR TITLE
fix(auth): Revoke tokens intead of trying to end session

### DIFF
--- a/.changeset/famous-coats-deny.md
+++ b/.changeset/famous-coats-deny.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Call token revocation endpoint on signout instead of calling endsession.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -31,6 +31,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=10"
+  },
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts ",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts --sourcemap inline",

--- a/packages/auth/src/constants.ts
+++ b/packages/auth/src/constants.ts
@@ -1,3 +1,4 @@
 export const IDENTITY_ROOT = "https://identity.api.navigraph.com";
 export const IDENTITY_DEVICE_AUTH = IDENTITY_ROOT + "/connect/deviceauthorization";
 export const IDENTITY_ENDSESSION_ENDPOINT = IDENTITY_ROOT + "/connect/endsession";
+export const IDENTITY_REVOCATION_ENDPOINT = IDENTITY_ROOT + "/connect/revocation";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## 📝 Description

This PR changes the signout behavior. Instead of trying to end the session with a call to `/connect/endsession`, we now call `/connect/revocation` to invalidate the refresh token.

## ⛳️ Current behavior

On signout, an attempt to invalidate the session is made by calling `/connect/endsession`.

## 🚀 New behavior

On signout, the last received refresh token is invalidated with a call to `/connect/revocation` 

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

 This flow works better for device-flow implementations, but when authorization code flow is implemented we'll have to reintroduce the endsession endpoint.
