### PR TITLE
Improve init process of auth module

### DIFF
--- a/.changeset/grumpy-shoes-drum.md
+++ b/.changeset/grumpy-shoes-drum.md
@@ -1,0 +1,7 @@
+---
+"@navigraph/auth": patch
+---
+
+Reduce amount of `onAuthStateChanged` events sent during init process, making it easier to track when the module is properly initialized.
+
+Previously, a set up `onAuthStateChanged` event listener would receive `null` before the modules had fully initialized. With this new behavior, when the module has not yet declared itself ready, the initial state update will be _delayed_ until such is the case.

--- a/examples/getting-started/src/hooks/useNavigraphAuth.tsx
+++ b/examples/getting-started/src/hooks/useNavigraphAuth.tsx
@@ -37,12 +37,12 @@ function useProvideAuth() {
   // component that utilizes this hook to re-render with the latest auth object.
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((u) => {
-      if (!isInitialized) setIsInitialized(true);
       setUser(u);
+      if (!isInitialized) setIsInitialized(true);
     });
     // Cleanup subscription on unmount
     return () => unsubscribe();
-  }, [isInitialized]);
+  }, []);
 
   return {
     user,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->



## 📝 Description

Reduces amount of `onAuthStateChanged` events sent during init process, making it easier to track when the module is properly initialized.

## ⛳️ Current behavior

Previously, a set up `onAuthStateChanged` event listener would receive `null` before the modules had fully initialized.
## 🚀 New behavior

With this new behavior, when the module has not yet declared itself ready, the initial state update will be _delayed_ until such is the case.


## 💣 Is this a breaking change (Yes/No):

No
