### PR TITLE
Remove max attempts from device flow login

### DIFF
--- a/.changeset/early-needles-mate.md
+++ b/.changeset/early-needles-mate.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Removed max attempts from the device flow login to use the default time set by the identity server

--- a/packages/auth/src/flows/device-flow.ts
+++ b/packages/auth/src/flows/device-flow.ts
@@ -14,8 +14,6 @@ import type { DeviceFlowCallback, User } from "../public-types";
 import type { AuthorizationResponse, FailedAuthorizationResponse, TokenResponse } from "../types";
 import { parseUser, tokenCall } from "./shared";
 
-const MAX_ATTEMPTS = 60; // 60 * 5 = 300 seconds / five minutes
-
 /**
  * Initializes a device flow login sequence.
  * @param callback - A callback that will be called with the initial parameters, such as the QR code or the verification uri and code.
@@ -94,10 +92,6 @@ async function poll(
   params: AuthorizationResponse & { code_verifier: string },
   attempts = 0
 ): Promise<TokenResponse> {
-  if (attempts >= MAX_ATTEMPTS) {
-    throw new Error("Unable to sign in with device flow. Max attempts reached.");
-  }
-
   await new Promise((resolve) => setTimeout(resolve, params.interval));
 
   try {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

## 📝 Description

This PR removes the max attempts setting in the device flow to use the default time set by identity server instead.

## ⛳️ Current behavior

Currently the max attempts is set to equal 5 minutes.

## 🚀 New behavior

Now we wait until identity server responds with either a successful response or an error that the session has expired.

