### PR TITLE
Support asynchronous storage implementations

### DIFF
--- a/.changeset/shiny-actors-sin.md
+++ b/.changeset/shiny-actors-sin.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Support asynchronous CustomStorage implementations

--- a/packages/auth/src/api.ts
+++ b/packages/auth/src/api.ts
@@ -80,7 +80,7 @@ export const getAuth = ({ keys, storage }: AuthParameters = {}): NavigraphAuth =
 const loadPersistedCredentials = async (app: NavigraphApp) => {
   if (INITIALIZED) return Promise.resolve();
 
-  const REFRESH_TOKEN = tokenStorage.getRefreshToken();
+  const REFRESH_TOKEN = await tokenStorage.getRefreshToken();
 
   if (REFRESH_TOKEN) {
     await tokenCall({

--- a/packages/auth/src/flows/shared.ts
+++ b/packages/auth/src/flows/shared.ts
@@ -12,10 +12,10 @@ export async function tokenCall(params: Record<string, string>) {
       new URLSearchParams(params),
       { headers: { "Content-Type": "application/x-www-form-urlencoded" }} // prettier-ignore
     )
-    .then(({ data }) => {
+    .then(async ({ data }) => {
       if (data.access_token && data.refresh_token) {
-        tokenStorage.setAccessToken(data.access_token);
-        tokenStorage.setRefreshToken(data.refresh_token);
+        await tokenStorage.setAccessToken(data.access_token);
+        await tokenStorage.setRefreshToken(data.refresh_token);
         setUser(parseUser(data.access_token));
       }
       return data;

--- a/packages/auth/src/internal.ts
+++ b/packages/auth/src/internal.ts
@@ -38,9 +38,9 @@ export const setUser = (user: User | null) => {
 
 export const setInitialized = (initialized: boolean) => (INITIALIZED = initialized);
 
-export const signOut = () => {
+export const signOut = async () => {
   const app = getApp();
-  const refreshToken = tokenStorage.getRefreshToken();
+  const refreshToken = await tokenStorage.getRefreshToken();
 
   if (app && refreshToken) {
     navigraphRequest
@@ -56,7 +56,7 @@ export const signOut = () => {
       .catch(() => Logger.warning("Failed to revoke token on signout"));
   }
 
-  tokenStorage.setAccessToken();
-  tokenStorage.setRefreshToken();
+  await tokenStorage.setAccessToken();
+  await tokenStorage.setRefreshToken();
   setUser(null);
 };

--- a/packages/auth/src/network.ts
+++ b/packages/auth/src/network.ts
@@ -5,8 +5,8 @@ import { LISTENERS, tokenStorage } from "./internal";
 
 export const navigraphRequest = axios.create();
 
-navigraphRequest.interceptors.request.use((config) => {
-  const token = tokenStorage.getAccessToken();
+navigraphRequest.interceptors.request.use(async (config) => {
+  const token = await tokenStorage.getAccessToken();
 
   if (token) {
     config.headers = {
@@ -22,7 +22,7 @@ navigraphRequest.interceptors.response.use(
   (res) => res,
   async (error: AxiosError) => {
     const app = getApp();
-    const REFRESH_TOKEN = tokenStorage.getRefreshToken();
+    const REFRESH_TOKEN = await tokenStorage.getRefreshToken();
 
     if (app && error?.response?.status === 401 && REFRESH_TOKEN) {
       const tokenResponse = await tokenCall({
@@ -33,8 +33,8 @@ navigraphRequest.interceptors.response.use(
       });
 
       if (tokenResponse.refresh_token) {
-        tokenStorage.setAccessToken(tokenResponse.access_token);
-        tokenStorage.setRefreshToken(tokenResponse.refresh_token);
+        await tokenStorage.setAccessToken(tokenResponse.access_token);
+        await tokenStorage.setRefreshToken(tokenResponse.refresh_token);
 
         return axios.request({
           ...error.config,

--- a/packages/auth/src/public-types.ts
+++ b/packages/auth/src/public-types.ts
@@ -35,8 +35,8 @@ export type Unsubscribe = () => void;
 
 /** TODO: Add description */
 export type CustomStorage = {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
+  getItem(key: string): string | null | Promise<string | null>;
+  setItem(key: string, value: string): void | Promise<void>;
 };
 
 export type StorageKeys = {


### PR DESCRIPTION
## 📝 Description

This PR makes the first iteration on `CustomStorage`, with the introduction of support for async storage implementations.

## ⛳️ Current behavior

Only synchronous storage implementations such as localStorage can be used in `CustomStorage`

## 🚀 New behavior

Asynchronous storage implementations can be used in `CustomStorage`

## 💣 Is this a breaking change (Yes/No):

No
