### PR TITLE
Support cancellation of authentication requests

### DIFF
--- a/.changeset/angry-pillows-heal.md
+++ b/.changeset/angry-pillows-heal.md
@@ -1,0 +1,6 @@
+---
+"@navigraph/auth": patch
+"@navigraph/app": patch
+---
+
+Introduced optional signal parameter that can be used to abort authentication attempts.

--- a/packages/app/src/errors.ts
+++ b/packages/app/src/errors.ts
@@ -36,6 +36,13 @@ export class InvalidClientError extends Error {
   }
 }
 
+export class AuthenticationAbortedError extends Error {
+  constructor() {
+    super("Unable to sign in with device flow. The authentication was aborted.");
+    this.name = "AuthenticationAborted";
+  }
+}
+
 export class NonGeoreferencedChartError extends Error {
   constructor(indexNumber: string) {
     super(`Could not calculate bounds for ${indexNumber || "a chart"} since it is not georeferenced`);


### PR DESCRIPTION

## 📝 Description

This PR enabled the developer to cancel authentication requests started by `signInWithDeviceFlow` prematurely.

## ⛳️ Current behavior

The polling used by the  `signInWithDeviceFlow` function cannot be stopped manually.

## 🚀 New behavior

The polling used by the  `signInWithDeviceFlow` function can be stopped manually using an `AbortController` signal.

## 💣 Is this a breaking change (Yes/No):

No

