### PR TITLE
Use Axios CancelTokens instead of AbortController

### DIFF
--- a/.changeset/six-pumas-sing.md
+++ b/.changeset/six-pumas-sing.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Refactored use of `AbortController` to instead use the more backwards-compatible `CancelToken` from `axios`.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,7 @@
+import axios from "axios";
+
 export * from "./api";
 export * from "./network";
 export * from "./public-types";
+
+export const CancelToken = axios.CancelToken;


### PR DESCRIPTION

## 📝 Description

This PR refactors usage of `AbortController` and replaces it with axios `CancelToken` instead, in an effort to natively support older browsers like Coherent GT.

## ⛳️ Current behavior

`AbortController` can be used to abort authentication requests. However, this API is not supported in older browsers like Coherent GT.

## 🚀 New behavior

`CancelToken` is used instead, making the cancellation work in older browsers as well, without polyfills.

## 💣 Is this a breaking change (Yes/No):

No, since no one has adopted the `AbortController` yet.
