### PR TITLE
Make `CancelToken`  optional and improve its types

### DIFF
--- a/.changeset/curly-papayas-grin.md
+++ b/.changeset/curly-papayas-grin.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Marked `cancelToken` as optional when using `signInWithDeviceFlow`. Also improved types of the `CancelToken` itself.

--- a/packages/auth/src/flows/device-flow.ts
+++ b/packages/auth/src/flows/device-flow.ts
@@ -8,9 +8,9 @@ import {
   InvalidClientError,
   InvalidScopeError,
 } from "@navigraph/app";
-import axios, { AxiosError, CancelToken } from "axios";
+import axios, { AxiosError } from "axios";
 import { getIdentityDeviceAuthEndpoint } from "../constants";
-import type { DeviceFlowCallback, User } from "../public-types";
+import type { NavigraphCancelToken, DeviceFlowCallback, User } from "../public-types";
 import type { AuthorizationResponse, FailedAuthorizationResponse, TokenResponse } from "../types";
 import { parseUser, tokenCall } from "./shared";
 
@@ -24,10 +24,11 @@ import { parseUser, tokenCall } from "./shared";
  *
  * @example
  * ```javascript
+ * const cancelSource = CancelToken.source();
  * // Initialize device flow sequence
  * auth.signInWithDeviceFlow((p) => {
  *   // Display the code to user & wait for user complete flow
- * }).then((u) => setUser(u));
+ * }, cancelSource.token).then((u) => setUser(u));
  * ```
  *
  * @throws {@link NotInitializedError} - If the SDK is not initialized.
@@ -41,7 +42,7 @@ import { parseUser, tokenCall } from "./shared";
  */
 export async function signInWithDeviceFlow(
   callback: DeviceFlowCallback,
-  cancelToken: CancelToken
+  cancelToken?: NavigraphCancelToken
 ): Promise<User> {
   const app = getApp();
 
@@ -93,7 +94,7 @@ export async function signInWithDeviceFlow(
 async function poll(
   app: NavigraphApp,
   params: AuthorizationResponse & { code_verifier: string },
-  cancelToken?: CancelToken,
+  cancelToken?: NavigraphCancelToken,
   attempts = 0
 ): Promise<TokenResponse> {
   await new Promise((resolve) => setTimeout(resolve, params.interval));

--- a/packages/auth/src/flows/shared.ts
+++ b/packages/auth/src/flows/shared.ts
@@ -1,11 +1,11 @@
 import { AuthenticationAbortedError, Logger, Scope } from "@navigraph/app";
-import axios, { CancelToken } from "axios";
+import axios from "axios";
 import { getIdentityTokenEndpoint } from "../constants";
 import { setUser, tokenStorage } from "../internal";
-import { User } from "../public-types";
+import { NavigraphCancelToken, User } from "../public-types";
 import { TokenResponse } from "../types";
 
-export async function tokenCall(params: Record<string, string>, cancelToken?: CancelToken) {
+export async function tokenCall(params: Record<string, string>, cancelToken?: NavigraphCancelToken) {
   return axios
     .post<TokenResponse>(getIdentityTokenEndpoint(), new URLSearchParams(params), {
       cancelToken,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
-
+import { NavigraphCancelTokenStatic } from "./public-types";
 export * from "./api";
 export * from "./network";
 export * from "./public-types";
 
-export const CancelToken = axios.CancelToken;
+export const CancelToken = axios.CancelToken as NavigraphCancelTokenStatic;

--- a/packages/auth/src/public-types.ts
+++ b/packages/auth/src/public-types.ts
@@ -55,32 +55,39 @@ export interface NavigraphAuth {
    * @returns {User|null} The currently authenticated user
    */
   getUser: () => User | null;
-  /**
-   * Initializes a device flow login sequence.
-   * @param callback - A callback that will be called with the initial parameters, such as the QR code or the verification uri and code.
-   *
-   * See
-   * {@link https://developers.navigraph.com/docs/authentication/device-authorization Device Authorization Flow With PKCE} and
-   * {@link https://developers.navigraph.com/docs/authentication/pkce Proof Key for Code Exchange (PKCE)} for detailed documentation.
-   *
-   * @example
-   * ```javascript
-   * // Initialize device flow sequence
-   * auth.signInWithDeviceFlow((p) => {
-   *   // Display the code to user & wait for user complete flow
-   * }).then((u) => setUser(u));
-   * ```
-   *
-   * @throws {@link NotInitializedError} - If the SDK is not initialized.
-   * @throws {@link InvalidClientError} - If the client id or secret is invalid.
-   * @throws {@link InvalidScopeError} - If the client contains one or several invalid scopes.
-   * @throws {@link UserDeniedAccessError} - If the user denied access.
-   * @throws {@link DeviceFlowTokenExpiredError} - If the user failed to authenticate within 5 mins.
-   *
-   * @async
-   * @returns {Promise<User>} A promise that resolves with the user object.
-   */
+  /** @inheritdoc */
   signInWithDeviceFlow: typeof signInWithDeviceFlow;
   /** Indicates whether the auth module has made an attempt to resume a previous session. */
   isInitialized: () => boolean;
+}
+
+export interface CancelStatic {
+  new (message?: string): Cancel;
+}
+
+export interface Cancel {
+  message: string;
+}
+
+export interface Canceler {
+  (message?: string): void;
+}
+
+export interface NavigraphCancelTokenStatic {
+  new (executor: (cancel: Canceler) => void): NavigraphCancelToken;
+  source(): CancelTokenSource;
+}
+
+/** A `CancelToken`, as defined by Axios. Can be used to abort ongoing sign-in attempts after polling has already started. */
+export interface NavigraphCancelToken {
+  promise: Promise<Cancel>;
+  reason?: Cancel;
+  throwIfRequested(): void;
+}
+
+export interface CancelTokenSource {
+  /** Cancellation token to be provided to the SDK */
+  token: NavigraphCancelToken;
+  /** Cancels any requests that are referencing the associated {@link NavigraphCancelToken} */
+  cancel: Canceler;
 }


### PR DESCRIPTION


## 📝 Description

A previous release introduced `CancelTokens`, but it was erroneously added as a required parameter to `auth.signInWithDeviceFlow` - causing a breaking change. This PR makes it optional and improves the types of the CancelToken.

