### PR TITLE
Add chart categories to `Chart` type

### DIFF
--- a/.changeset/happy-cups-fry.md
+++ b/.changeset/happy-cups-fry.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/charts": patch
+---
+
+Added `ChartCategory` type for improved type-safety when dealing with chart objects.

--- a/packages/charts/src/public-types.ts
+++ b/packages/charts/src/public-types.ts
@@ -26,6 +26,8 @@ export interface BoundingBoxes {
   insets: Inset[];
 }
 
+export type ChartCategory = "APT" | "REF" | "ARR" | "DEP" | "APP";
+
 export type Chart = {
   image_day: string;
   image_night: string;
@@ -33,7 +35,7 @@ export type Chart = {
   thumb_night: string;
   icao_airport_identifier: string;
   id: string;
-  category: string;
+  category: ChartCategory;
   precision_approach: boolean | null;
   index_number: string;
   name: string;


### PR DESCRIPTION
## ⛳️ Current behavior

The `Chart` type defines `category` as `string`.

## 🚀 New behavior

The type now identifies `"APT" | "REF" | "ARR" | "DEP" | "APP"` as valid values.

## 💣 Is this a breaking change (Yes/No):

It shouldn't be. Existing implementations that rely on this property being a `string` should still behave the same.
