### PR TITLE
Ensure that only one SDK instance initializes at any given time

### DIFF
--- a/.changeset/breezy-rockets-return.md
+++ b/.changeset/breezy-rockets-return.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": minor
+---
+
+Added locking behavior for SDK initialization process. This should prevent multiple instances of the SDK from initializing at the same time in a context where the tokens are shared, such as within an MSFS project with multiple entrypoints.

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
   modulePathIgnorePatterns: ["<rootDir>/packages/navigraph"],
+  setupFiles: ["jest-localstorage-mock"],
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",
+    "jest-localstorage-mock": "^2.4.26",
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^29.0.5",

--- a/packages/auth/src/flows/device-flow.test.ts
+++ b/packages/auth/src/flows/device-flow.test.ts
@@ -33,17 +33,35 @@ const tokenOKResponse = {
 describe("Device Flow Authentication", () => {
   let auth: ReturnType<typeof getAuth>;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     initializeApp({
       clientId: "test_client",
       clientSecret: "secret",
       scopes: [Scope.CHARTS],
     });
 
+    timeoutSpy.mockImplementation((cb) => ogTimeout(cb, 0));
+
+    // Simulate an expired token request
+    localStorage.setItem("refresh_token", "invalid_refresh_token");
+    postSpy.mockImplementation(() =>
+      Promise.reject({
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: "bad request",
+        },
+      })
+    );
+
     auth = getAuth();
+
+    // Wait for the lock to be established and released
+    await new Promise((resolve) => ogTimeout(resolve, 50));
   });
 
   beforeEach(() => {
+    localStorage.clear();
     jest.clearAllMocks();
   });
 

--- a/packages/auth/src/lib/isExpiredToken.ts
+++ b/packages/auth/src/lib/isExpiredToken.ts
@@ -1,0 +1,11 @@
+import { parseJwt } from "../flows/shared";
+
+/**
+ * Check if access token is expired, or will expire within the given threshold.
+ * @param accessToken Access token
+ */
+export default function isExpiredToken(accessToken: string) {
+  const token = parseJwt(accessToken);
+  if (!token) return true;
+  return token.exp * 1000 < Date.now();
+}

--- a/packages/auth/src/lib/storageLock.ts
+++ b/packages/auth/src/lib/storageLock.ts
@@ -1,0 +1,75 @@
+// Inspiration & Source: https://github.com/taylorhakes/localstorage-lock
+// Modified to support async functions
+
+import { storage } from "../internal";
+
+function getId() {
+  return `${Date.now()}:${Math.random()}`;
+}
+
+type Options = {
+  timeout?: number;
+  lockWriteTime?: number;
+  checkTime?: number;
+  retry?: boolean;
+};
+
+type Lock = {
+  id: string;
+  time: number;
+};
+
+export async function runWithLock(
+  key: string,
+  fn: () => Promise<void>,
+  { timeout = 1000, lockWriteTime = 50, checkTime = 10, retry = true }: Options = {}
+) {
+  const timerRunWithLock = async () =>
+    new Promise<void>((r) =>
+      setTimeout(async () => {
+        await runWithLock.bind(null, key, fn, { timeout, lockWriteTime, checkTime, retry })();
+        r();
+      }, checkTime)
+    );
+
+  const result = await storage.getItem(key);
+
+  if (result) {
+    // Check to make sure the lock hasn't expired
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const data: Lock = JSON.parse(result);
+    if (data.time >= Date.now() - timeout) {
+      if (retry) await timerRunWithLock();
+      return;
+    } else {
+      await storage.setItem(key, "");
+    }
+  }
+
+  const id = getId();
+  await storage.setItem(key, JSON.stringify({ id, time: Date.now() }));
+
+  // Delay a bit, to see if another worker is in this section
+  await new Promise<void>((r) =>
+    setTimeout(async () => {
+      const currentResult = await storage.getItem(key);
+      if (!currentResult) return;
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const data: Lock = JSON.parse(currentResult);
+
+      if (data.id !== id) {
+        if (retry) await timerRunWithLock();
+        r();
+        return;
+      }
+
+      try {
+        await fn();
+      } finally {
+        await storage.setItem(key, "");
+      }
+      r();
+    }, lockWriteTime)
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9578,6 +9578,11 @@ jest-leak-detector@^29.5.0:
     jest-get-type "^29.4.3"
     pretty-format "^29.5.0"
 
+jest-localstorage-mock@^2.4.26:
+  version "2.4.26"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz#7d57fb3555f2ed5b7ed16fd8423fd81f95e9e8db"
+  integrity sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==
+
 jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
@@ -15564,8 +15569,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## 📝 Description

When dealing with authentication in MSFS using our SDK, we encountered some weird behavior that would cause the SDK to suddenly fail to automatically sign in a user after a restart. After some investigation, we think that the cause behind this is the fact that we were creating multiple instances of the SDK (one per instrument) at the same time. Since we wanted them all to share the same credentials, this caused a race condition where the same refresh token would be used multiple times - which will ultimately result in only one successful request and several other failed ones.

Ideally, we'd just like to have one instance handle the refresh and then let the others wait for the updated tokens, but since the instruments are in completely different contexts - this proved to be a challenge.

## ⛳️ Current behavior

Several instances of the SDK may access and subsequently, send the same credentials to identity at the same time despite refresh tokens only being valid for one request. This causes unintentional signouts.

## 🚀 New behavior

Only one instance of the SDK may run the initialization process at any given moment.

Also, the access token is checked for validity before attempting to refresh tokens. This should result in a slight speedup.

## 💣 Is this a breaking change (Yes/No):

No. 

## 📝 Additional Information

The locking will work automatically, but for MSFS a custom `storage` that implements the `DataStore` API should be provided to `getAuth` in order for persistence to be guaranteed.
