### PR TITLE
Add optional `verify` parameter to `getUser`

### DIFF
--- a/.changeset/olive-hounds-divide.md
+++ b/.changeset/olive-hounds-divide.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": minor
+---
+
+Added a `verify` parameter to the `getUser` function that optionally forces a re-verification of the user's credentials. Can be useful when syncing multiple instances of the SDK running in different contexts with shared credentials.

--- a/packages/auth/src/internal.ts
+++ b/packages/auth/src/internal.ts
@@ -1,7 +1,10 @@
-import { getApp, Logger } from "@navigraph/app";
+import { getApp, Logger, NotInitializedError } from "@navigraph/app";
 import { getIdentityRevocationEndpoint } from "./constants";
 import { navigraphRequest } from "./network";
 import { CustomStorage, Listener, StorageKeys, User } from "./public-types";
+import { parseUser, tokenCall } from "./flows/shared";
+import isExpiredToken from "./lib/isExpiredToken";
+import { runWithLock } from "./lib/storageLock";
 
 export let USER: User | null = null;
 export let INITIALIZED = false;
@@ -34,6 +37,52 @@ export const tokenStorage = {
 export const setUser = (user: User | null) => {
   USER = user;
   LISTENERS.forEach((listener) => listener(user));
+};
+
+/** Grabs information about the currently authenticated user from memory
+ * @param verify Whether to verify the validity of the associated access token. If true, the function will return a promise instead.
+ * @returns {User|null} The currently authenticated user
+ * @throws {NotInitializedError} If the SDK has not been initialized
+ */
+export function getUser(): User | null;
+export function getUser(verify?: false): User | null;
+export function getUser(verify?: true): Promise<User | null>;
+export function getUser(verify?: boolean): User | null | Promise<User | null> {
+  return verify ? verifyUser() : USER;
+}
+
+/** Verifies the validity of the currently stored access token. If the token is invalid or expired, a refresh attempt will be made.
+ * @returns {Promise<User|null>} The currently authenticated user
+ * @throws {NotInitializedError} If the SDK has not been initialized
+ */
+export const verifyUser = async () => {
+  const app = getApp();
+  if (!app) throw new NotInitializedError("Auth");
+
+  const ACCESS_TOKEN = await tokenStorage.getAccessToken();
+
+  if (ACCESS_TOKEN && !isExpiredToken(ACCESS_TOKEN)) {
+    const user = parseUser(ACCESS_TOKEN);
+    setUser(user);
+    return user;
+  }
+
+  return new Promise<User | null>((resolve, reject) => {
+    runWithLock("NAVIGRAPH_SDK_INIT", async () => {
+      const REFRESH_TOKEN = await tokenStorage.getRefreshToken();
+
+      if (REFRESH_TOKEN) {
+        await tokenCall({
+          client_id: app.clientId,
+          client_secret: app.clientSecret,
+          grant_type: "refresh_token",
+          refresh_token: REFRESH_TOKEN,
+        }).catch(reject);
+      }
+
+      resolve(USER);
+    }).catch(reject);
+  });
 };
 
 export const setInitialized = (initialized: boolean) => (INITIALIZED = initialized);

--- a/packages/auth/src/public-types.ts
+++ b/packages/auth/src/public-types.ts
@@ -1,4 +1,5 @@
 import { signInWithDeviceFlow } from "./flows/device-flow";
+import { getUser } from "./internal";
 
 export type DeviceFlowParams = {
   /** The url used to sign in manually (url excl. code)  */
@@ -51,10 +52,8 @@ export interface NavigraphAuth {
   onAuthStateChanged: (callback: Listener) => Unsubscribe;
   /** Signs out the currently authenticated user. */
   signOut: () => void;
-  /** Grabs information about the currently authenticated user.
-   * @returns {User|null} The currently authenticated user
-   */
-  getUser: () => User | null;
+  /** @inheritdoc */
+  getUser: typeof getUser;
   /** @inheritdoc */
   signInWithDeviceFlow: typeof signInWithDeviceFlow;
   /** Indicates whether the auth module has made an attempt to resume a previous session. */


### PR DESCRIPTION


## 📝 Description

Added a `verify` parameter to the `getUser` function that optionally forces a re-verification of the user's credentials. Can be useful when syncing multiple instances of the SDK running in different contexts with shared credentials.

## ⛳️ Current behavior

When running multiple instances of the SDK in separate environments with shared credentials, signing in to one instance will not reflect on the others.

## 🚀 New behavior

To at least make it possible for other instances to "catch up" to the signed-in instance, an optional `verify` parameter is added to `getUser`. When this is done, the signature changes and the function returns a promise that is resolved once an attempt has been made to check for existing valid credentials.

## 💣 Is this a breaking change (Yes/No):

That is not the intention. The API should stay the same since the parameter is optional and the signature only changes once the parameter is provided with a truthy value.
