### PR TITLE
Document `type_code` property with all possible values

### DIFF
--- a/.changeset/fair-guests-scream.md
+++ b/.changeset/fair-guests-scream.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/charts": patch
+---
+
+Added exhaustive types to the `Chart.type_code` property using enums that contain all possible types in the source.

--- a/packages/charts/src/api/chartTypeCodes.ts
+++ b/packages/charts/src/api/chartTypeCodes.ts
@@ -1,99 +1,51 @@
 export enum ApproachChartTypeCode {
-  /** @precision true */
   ILSApproachChart = "01",
-  /** @precision true */
   PARApproachChart = "02",
-  /** @precision false */
   VORApproachChart = "03",
-  /** @precision false */
   TACANApproachChart = "04",
-  /** @precision false */
   NonPrecisionHelicopterApproachChart = "05",
-  /** @precision false */
   NDBApproachChart = "06",
-  /** @precision false */
   DFApproachChart = "07",
-  /** @precision false */
   ASRApproachChart = "08",
-  /** @precision false */
   VORDMERNAVApproachChart = "09",
-  /** @precision true */
   ILSSACatI = "11",
-  /** @precision true */
   PrecisionHelicopterApproachChart = "15",
-  /** @precision true */
   ILSCatIIApproachChart = "1A",
-  /** @precision true */
   ILSCatIIAndIIIAApproachChart = "1B",
-  /** @precision true */
   ILSCatIIAndIIIAAndBApproachChart = "1C",
-  /** @precision false */
   LOCApproachChart = "1D",
-  /** @precision false */
   LOCBackCrsApproachChart = "1E",
-  /** @precision false */
   LDAApproachChart = "1F",
-  /** @precision false */
   SDFApproachChart = "1G",
-  /** @precision true */
   MLSApproachChart = "1H",
-  /** @precision false */
   VisualApproachChartExcludesCvfps = "1J",
-  /** @precision false */
   VicinityChart = "1K",
-  /** @precision false */
   RNAVApproachChartExcludesVORDMERNAV = "1L",
-  /** @precision false */
   SoleUseGpsNonPrecisionApproachChartExcludes = "1M",
-  /** @precision false */
   SoleUseFmsApproachChart = "1N",
-  /** @precision true */
   ILSSACatII = "1P",
-  /** @precision true */
   ILSApproachOrGpsChart = "21",
-  /** @precision true */
   PARApproachOrGpsChart = "22",
-  /** @precision false */
   VORApproachOrGpsChart = "23",
-  /** @precision false */
   TACANApproachOrGpsChart = "24",
-  /** @precision false */
   HelicopterApproachOrGpsChart = "25",
-  /** @precision false */
   NDBApproachOrGpsChart = "26",
-  /** @precision false */
   DFApproachOrGpsChart = "27",
-  /** @precision false */
   ASRApproachOrGpsChart = "28",
-  /** @precision false */
   VORDMERNAVApproachOrGpsChart = "29",
-  /** @precision true */
   ILSCatIIApproachOrGpsChart = "2A",
-  /** @precision true */
   ILSCatIIAndIIIAApproachOrGpsChart = "2B",
-  /** @precision true */
   ILSCatIiAndIiiAAndBApproachOrGpsChart = "2C",
-  /** @precision false */
   LOCApproachOrGpsChart = "2D",
-  /** @precision false */
   LOCBackCrsApproachOrGpsChart = "2E",
-  /** @precision false */
   LDAApproachOrGpsChart = "2F",
-  /** @precision false */
   SDFApproachOrGpsChart = "2G",
-  /** @precision true */
   MLSApproachOrGpsChart = "2H",
-  /** @precision false */
   VisualApproachOrGpsChart = "2J",
-  /** @precision false */
   VicinityOrGpsChart = "2K",
-  /** @precision false */
   SoleUseFmsApproachOrGpsChart = "2N",
-  /** @precision false */
   RNPProcedures = "RP",
-  /** @precision true */
   GLSApproachCharts = "RS",
-  /** @precision false */
   VFRArrivalsAndDepartures = "VF",
 }
 

--- a/packages/charts/src/api/chartTypeCodes.ts
+++ b/packages/charts/src/api/chartTypeCodes.ts
@@ -1,51 +1,99 @@
 export enum ApproachChartTypeCode {
+  /** @precision true */
   ILSApproachChart = "01",
+  /** @precision true */
   PARApproachChart = "02",
+  /** @precision false */
   VORApproachChart = "03",
+  /** @precision false */
   TACANApproachChart = "04",
+  /** @precision false */
   NonPrecisionHelicopterApproachChart = "05",
+  /** @precision false */
   NDBApproachChart = "06",
+  /** @precision false */
   DFApproachChart = "07",
+  /** @precision false */
   ASRApproachChart = "08",
+  /** @precision false */
   VORDMERNAVApproachChart = "09",
+  /** @precision true */
   ILSSACatI = "11",
+  /** @precision true */
   PrecisionHelicopterApproachChart = "15",
+  /** @precision true */
   ILSCatIIApproachChart = "1A",
+  /** @precision true */
   ILSCatIIAndIIIAApproachChart = "1B",
+  /** @precision true */
   ILSCatIIAndIIIAAndBApproachChart = "1C",
+  /** @precision false */
   LOCApproachChart = "1D",
+  /** @precision false */
   LOCBackCrsApproachChart = "1E",
+  /** @precision false */
   LDAApproachChart = "1F",
+  /** @precision false */
   SDFApproachChart = "1G",
+  /** @precision true */
   MLSApproachChart = "1H",
+  /** @precision false */
   VisualApproachChartExcludesCvfps = "1J",
+  /** @precision false */
   VicinityChart = "1K",
+  /** @precision false */
   RNAVApproachChartExcludesVORDMERNAV = "1L",
+  /** @precision false */
   SoleUseGpsNonPrecisionApproachChartExcludes = "1M",
+  /** @precision false */
   SoleUseFmsApproachChart = "1N",
+  /** @precision true */
   ILSSACatII = "1P",
+  /** @precision true */
   ILSApproachOrGpsChart = "21",
+  /** @precision true */
   PARApproachOrGpsChart = "22",
+  /** @precision false */
   VORApproachOrGpsChart = "23",
+  /** @precision false */
   TACANApproachOrGpsChart = "24",
+  /** @precision false */
   HelicopterApproachOrGpsChart = "25",
+  /** @precision false */
   NDBApproachOrGpsChart = "26",
+  /** @precision false */
   DFApproachOrGpsChart = "27",
+  /** @precision false */
   ASRApproachOrGpsChart = "28",
+  /** @precision false */
   VORDMERNAVApproachOrGpsChart = "29",
+  /** @precision true */
   ILSCatIIApproachOrGpsChart = "2A",
+  /** @precision true */
   ILSCatIIAndIIIAApproachOrGpsChart = "2B",
+  /** @precision true */
   ILSCatIiAndIiiAAndBApproachOrGpsChart = "2C",
+  /** @precision false */
   LOCApproachOrGpsChart = "2D",
+  /** @precision false */
   LOCBackCrsApproachOrGpsChart = "2E",
+  /** @precision false */
   LDAApproachOrGpsChart = "2F",
+  /** @precision false */
   SDFApproachOrGpsChart = "2G",
+  /** @precision true */
   MLSApproachOrGpsChart = "2H",
+  /** @precision false */
   VisualApproachOrGpsChart = "2J",
+  /** @precision false */
   VicinityOrGpsChart = "2K",
+  /** @precision false */
   SoleUseFmsApproachOrGpsChart = "2N",
+  /** @precision false */
   RNPProcedures = "RP",
+  /** @precision true */
   GLSApproachCharts = "RS",
+  /** @precision false */
   VFRArrivalsAndDepartures = "VF",
 }
 

--- a/packages/charts/src/api/chartTypeCodes.ts
+++ b/packages/charts/src/api/chartTypeCodes.ts
@@ -1,0 +1,167 @@
+export enum ApproachChartTypeCode {
+  /** @precision true */
+  ILSApproachChart = "01",
+  /** @precision true */
+  PARApproachChart = "02",
+  /** @precision false */
+  VORApproachChart = "03",
+  /** @precision false */
+  TACANApproachChart = "04",
+  /** @precision false */
+  NonPrecisionHelicopterApproachChart = "05",
+  /** @precision false */
+  NDBApproachChart = "06",
+  /** @precision false */
+  DFApproachChart = "07",
+  /** @precision false */
+  ASRApproachChart = "08",
+  /** @precision false */
+  VORDMERNAVApproachChart = "09",
+  /** @precision true */
+  ILSSACatI = "11",
+  /** @precision true */
+  PrecisionHelicopterApproachChart = "15",
+  /** @precision true */
+  ILSCatIIApproachChart = "1A",
+  /** @precision true */
+  ILSCatIIAndIIIAApproachChart = "1B",
+  /** @precision true */
+  ILSCatIIAndIIIAAndBApproachChart = "1C",
+  /** @precision false */
+  LOCApproachChart = "1D",
+  /** @precision false */
+  LOCBackCrsApproachChart = "1E",
+  /** @precision false */
+  LDAApproachChart = "1F",
+  /** @precision false */
+  SDFApproachChart = "1G",
+  /** @precision true */
+  MLSApproachChart = "1H",
+  /** @precision false */
+  VisualApproachChartExcludesCvfps = "1J",
+  /** @precision false */
+  VicinityChart = "1K",
+  /** @precision false */
+  RNAVApproachChartExcludesVORDMERNAV = "1L",
+  /** @precision false */
+  SoleUseGpsNonPrecisionApproachChartExcludes = "1M",
+  /** @precision false */
+  SoleUseFmsApproachChart = "1N",
+  /** @precision true */
+  ILSSACatII = "1P",
+  /** @precision true */
+  ILSApproachOrGpsChart = "21",
+  /** @precision true */
+  PARApproachOrGpsChart = "22",
+  /** @precision false */
+  VORApproachOrGpsChart = "23",
+  /** @precision false */
+  TACANApproachOrGpsChart = "24",
+  /** @precision false */
+  HelicopterApproachOrGpsChart = "25",
+  /** @precision false */
+  NDBApproachOrGpsChart = "26",
+  /** @precision false */
+  DFApproachOrGpsChart = "27",
+  /** @precision false */
+  ASRApproachOrGpsChart = "28",
+  /** @precision false */
+  VORDMERNAVApproachOrGpsChart = "29",
+  /** @precision true */
+  ILSCatIIApproachOrGpsChart = "2A",
+  /** @precision true */
+  ILSCatIIAndIIIAApproachOrGpsChart = "2B",
+  /** @precision true */
+  ILSCatIiAndIiiAAndBApproachOrGpsChart = "2C",
+  /** @precision false */
+  LOCApproachOrGpsChart = "2D",
+  /** @precision false */
+  LOCBackCrsApproachOrGpsChart = "2E",
+  /** @precision false */
+  LDAApproachOrGpsChart = "2F",
+  /** @precision false */
+  SDFApproachOrGpsChart = "2G",
+  /** @precision true */
+  MLSApproachOrGpsChart = "2H",
+  /** @precision false */
+  VisualApproachOrGpsChart = "2J",
+  /** @precision false */
+  VicinityOrGpsChart = "2K",
+  /** @precision false */
+  SoleUseFmsApproachOrGpsChart = "2N",
+  /** @precision false */
+  RNPProcedures = "RP",
+  /** @precision true */
+  GLSApproachCharts = "RS",
+  /** @precision false */
+  VFRArrivalsAndDepartures = "VF",
+}
+
+export enum AirspaceChartTypeCode {
+  AreaChart = "A",
+  ClassBTCAOrTMAChart = "B",
+  EnrouteVisualChart = "C",
+  CAOQuickReferenceChart = "FF",
+}
+
+export enum AirportChartTypeCode {
+  AirportChart = "AP",
+  AirportFamiliarizationChart = "AF",
+  AirportQualificationChart = "AQ",
+  AirportBriefingChart = "P",
+  MiscAirportChart = "AA",
+  MiscGraphicChart = "MG",
+  NonAssignedTypeWillBeResearchedLater = "NA",
+  ColdTemperatureTable = "P1",
+  ParkingGatesSMGCSAndLowVisProcedureChart = "R",
+  NoseInParkingAndDockingCharts = "S",
+}
+
+export enum DepartureChartTypeCode {
+  SIDOrDPChart = "G",
+  SIDOrDPOrGPSChart = "G2",
+  RNAVOrBothGPSAndFMSAuthorizedDepartureChar = "GG",
+  RNPSIDOrDepartureChart = "GP",
+  EngineOutProcedures = "EO",
+  SoleUseFMSDepartureChart = "GH",
+  OpsdataEngineFailureProcedure = "OP",
+}
+
+export enum ArrivalChartTypeCode {
+  STARChart = "J",
+  STARChartOrGp = "J2",
+  RNAVOrBothGPSAndFMSAuthorizedArrivalChart = "JG",
+  SoleUseFMSArrivalChart = "JH",
+  RNPSTAROrArrivalChart = "JP",
+}
+
+export enum NoiseChartTypeCode {
+  NoiseAbatementChart = "N",
+}
+
+export enum TextChartTypeCode {
+  MiscTextPages = "ST",
+  TerminalTextPages = "TP",
+  TailoredTextPages = "TT",
+}
+
+// All typecodes merged in one enum
+export const ChartTypeCode = {
+  ...AirportChartTypeCode,
+  ...AirspaceChartTypeCode,
+  ...ApproachChartTypeCode,
+  ...DepartureChartTypeCode,
+  ...ArrivalChartTypeCode,
+  ...NoiseChartTypeCode,
+  ...TextChartTypeCode,
+};
+
+/** The type of chart, with higher granularity than a chart category. Can be used to facilitate more fine-grained filtering. */
+export type ChartTypeCode =
+  | ApproachChartTypeCode
+  | AirspaceChartTypeCode
+  | AirportChartTypeCode
+  | DepartureChartTypeCode
+  | ArrivalChartTypeCode
+  | NoiseChartTypeCode
+  | TextChartTypeCode;

--- a/packages/charts/src/api/getChartImage.test.ts
+++ b/packages/charts/src/api/getChartImage.test.ts
@@ -1,6 +1,7 @@
 import { navigraphRequest } from "@navigraph/auth";
 import getChartImage from "./getChartImage";
 import { Chart } from "./types";
+import { ChartTypeCode } from "./chartTypeCodes";
 
 const getSpy = jest.spyOn(navigraphRequest, "get");
 const consoleSpy = jest.spyOn(console, "error").mockImplementation();
@@ -13,6 +14,7 @@ const chart: Chart = {
   icao_airport_identifier: "ESSA",
   id: "ESSA01P1",
   category: "APT",
+  type_code: "P" as ChartTypeCode,
   bounding_boxes: null,
   precision_approach: null,
   index_number: "10-1P1",

--- a/packages/charts/src/api/types.ts
+++ b/packages/charts/src/api/types.ts
@@ -1,3 +1,5 @@
+import { ChartTypeCode } from "./chartTypeCodes";
+
 /**
  * A bounding box representation in pixels from the origin (top left) of the chart.
  *
@@ -61,6 +63,8 @@ export type Chart = {
   icao_airport_identifier: string;
   id: string;
   category: ChartCategory;
+  /** The type of chart, with higher granularity than {@link Chart.category category}. Can be used to facilitate more fine-grained filtering. */
+  type_code: ChartTypeCode;
   precision_approach: boolean | null;
   index_number: string;
   name: string;


### PR DESCRIPTION
## 📝 Description

This PR introduces types for the recently added `type_code` property. The types consist of enums and are aimed at making it easy for developers to pick & sort between charts with higher granularity.

## 💣 Is this a breaking change (Yes/No):

No
