### PR TITLE
Fix/missing-types

### DIFF
--- a/.changeset/lovely-timers-drop.md
+++ b/.changeset/lovely-timers-drop.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": minor
+---
+
+Reintroduced authentication-related types that went missing in `v1.2.22` following an internal reorganization.

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./lib/navigraphRequest";
+export { CancelToken, navigraphRequest, isAxiosError } from "./lib/navigraphRequest";
 export { default as getAuth } from "./lib/getAuth";
 export type * from "./flows/device-flow";
 export type { User, UserCallback, Unsubscribe } from "./internals/user";

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/navigraphRequest";
 export { default as getAuth } from "./lib/getAuth";
 export type * from "./flows/device-flow";
+export type { User, UserCallback, Unsubscribe } from "./internals/user";


### PR DESCRIPTION
## 📝 Description

This PR fixes an issue with recent releases that would cause the `User` type to not be reachable from client code.

## ⛳️ Current behavior

Importing the `User` type from `navigraph/auth` yields:

```
Exported variable 'auth' has or is using name 'User' from external module but cannot be named.
```

Using the `getAuth` function also yields:

```
Exported variable 'auth' has or is using name 'User' from external module but cannot be named.
```

## 🚀 New behavior

The above issues should now be gone!
