### PR TITLE
Add airport information endpoint access

### DIFF
--- a/.changeset/beige-books-design.md
+++ b/.changeset/beige-books-design.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/charts": minor
+---
+
+Added airport information endpoint access. This endpoint can be used to fetch details such as available fuel, types of repair services etc..

--- a/packages/charts/src/api/getAirportInfo.test.ts
+++ b/packages/charts/src/api/getAirportInfo.test.ts
@@ -1,0 +1,29 @@
+import { navigraphRequest } from "@navigraph/auth";
+import getAirportInfo from "./getAirportInfo";
+
+const getSpy = jest.spyOn(navigraphRequest, "get");
+const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+it("given a valid icao, when no user is authenticated, should return null and log an error", async () => {
+  getSpy.mockImplementation(() =>
+    Promise.reject({
+      message: "Request failed with status code 401",
+      isAxiosError: true,
+      response: {
+        status: 401,
+        data: "Unauthorized",
+      },
+    })
+  );
+
+  const response = await getAirportInfo({ icao: "ESSA" });
+
+  expect(response).toEqual(null);
+  expect(consoleSpy).toHaveBeenCalledWith(
+    "[Navigraph]",
+    "Failed to fetch airport information. Reason:",
+    "Request failed with status code 401"
+  );
+});
+
+// TODO: Figure out how to mock `navigraphRequest` without breaking the interceptors in order to simulate authenticated requests

--- a/packages/charts/src/api/getAirportInfo.ts
+++ b/packages/charts/src/api/getAirportInfo.ts
@@ -1,0 +1,17 @@
+import { Logger } from "@navigraph/app";
+import { navigraphRequest, isAxiosError } from "@navigraph/auth";
+import { getChartsApiRoot } from "../constants";
+import { AirportInfo } from "./types";
+
+/** Fetches general, useful information about an airport such as fuel types, repairs, and more
+ * @param options.icao - The ICAO code of an airport
+ * @returns {AirportInfo} An object containing information about the airport
+ */
+export default async function getAirportInfo({ icao }: { icao: string }): Promise<AirportInfo | null> {
+  const result = await navigraphRequest
+    .get<AirportInfo>(`${getChartsApiRoot()}/${icao}/airport`)
+    .catch((e: unknown) =>
+      Logger.err("Failed to fetch airport information. Reason:", isAxiosError(e) ? e.message : e)
+    );
+  return result?.data || null;
+}

--- a/packages/charts/src/api/types.ts
+++ b/packages/charts/src/api/types.ts
@@ -87,3 +87,70 @@ export type Chart = {
 export interface ChartsIndexResponse {
   charts: Chart[];
 }
+
+export type Fuel =
+  | "73 Octane"
+  | "80-87 Octane"
+  | "100 low lead (LL) octane"
+  | "100-130 octane"
+  | "115-145 octane"
+  | "Mogas"
+  | "JET"
+  | "JET A"
+  | "JET A-1"
+  | "Jet A+"
+  | "JET B"
+  | "JET 4"
+  | "JET 5";
+
+export type OxygenService = "High Pressure" | "Low Pressure" | "High Pressure Bottle" | "Low Pressure Bottle";
+
+export type Repairs = "Minor Engine" | "Major Airframe" | "Major Engine";
+
+export interface AirportInfo {
+  icao_airport_identifier: string;
+  iata_airport_designator: string;
+  longest_runway: number;
+  latitude: number;
+  longitude: number;
+  magnetic_variation: number;
+  elevation: number;
+  name: string;
+  city: string;
+  state_province_code: string;
+  state_province_name: string;
+  country_code: string;
+  country_name: string;
+  /** The type of fuel available at the airport or heliport. Empty means unknown. */
+  fuel_types: Fuel[];
+  /** The type of oxygen servicing available at the airport or heliport. Empty means unknown.  */
+  oxygen: OxygenService[];
+  /** The type of fuel available at the airport or heliport. Empty means unknown. */
+  repairs: Repairs[];
+  /**
+   * Indicates if landing fees are charged for private or non-revenue producing aircraft.
+   *
+   * **Note:** These fees will vary from no charge for aircraft below certain weight – no charge if fuel purchased – to charges for all landing aircraft.
+   * This field provides only a true/false indication, no specific details on what aircraft types must pay under what conditions are provided.
+   */
+  landing_fee: boolean;
+  /** Indicates if the airport/heliport is equipped with JASU and if that equipment is available to a public user of the airport/heliport */
+  jet_starting_unit: boolean;
+  /** Indicates if the airport supports precision approaches */
+  precision_airport: boolean;
+  /** Indicates if the airport has Beacon Lights. Beacon Lights are normally provided at any airport/heliport intended for use at night. */
+  beacon: boolean;
+  /** Indicates the availability of a government customs facility at the airport */
+  customs: boolean;
+  airport_type: string;
+  time_zone: string;
+  icao_code: string;
+  daylight_savings: boolean;
+  /** The Local Horizontal Reference Datum with which the Airport Reference Point (ARP) is associated */
+  datum_code: string;
+  revision_date: string;
+  parsed_cycle: string;
+  std_charts: boolean;
+  cao_charts: boolean;
+  vfr_charts: boolean;
+}

--- a/packages/charts/src/lib/getChartsAPI.ts
+++ b/packages/charts/src/lib/getChartsAPI.ts
@@ -1,6 +1,7 @@
 import { getApp, Logger, NotInitializedError, Scope } from "@navigraph/app";
 import getChartImage from "../api/getChartImage";
 import getChartsIndex from "../api/getChartsIndex";
+import getAirportInfo from "../api/getAirportInfo";
 
 /** Grabs a reference to an object containing available Navigraph Charts API functionality */
 export const getChartsAPI = () => {
@@ -17,5 +18,6 @@ export const getChartsAPI = () => {
   return {
     getChartsIndex,
     getChartImage,
+    getAirportInfo,
   };
 };


### PR DESCRIPTION

## 📝 Description

This PR introduces access to an endpoint that was previously not included. This endpoint can be used to fetch details such as available fuel, types of repair services etc..

