### PR TITLE
fix(auth): correctly handle token expiry threshold

### DIFF
--- a/.changeset/nice-eyes-sing.md
+++ b/.changeset/nice-eyes-sing.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Fixed token expiry check. Previously, a token would be considered expired 3 minutes **after** it expired, but the intention was to treat it as expired 3 minutes **before** its real expiry.

--- a/packages/auth/src/util/isExpiredToken.ts
+++ b/packages/auth/src/util/isExpiredToken.ts
@@ -11,5 +11,5 @@ export default function isExpiredToken(accessToken?: string, threshold = EXPIRY_
   if (!accessToken) return true;
   const decodedToken = decodeAccessToken(accessToken);
   if (!decodedToken) return true;
-  return decodedToken.exp * 1000 < Date.now() - threshold;
+  return decodedToken.exp * 1000 < Date.now() + threshold;
 }


### PR DESCRIPTION

## 📝 Description

Tokens are currently being passed as "valid" up to 3 minutes after their expiry. This causes unexpected bugs due to the credentials being invalid while the SDK still considers them functional.

## ⛳️ Current behavior

A token is considered expired 3 minutes **after** it really expired

## 🚀 New behavior

A token is considered expired 3 minutes **before** its real expiry.

## 💣 Is this a breaking change (Yes/No):

Hopefully not, it should improve the situation in some scenarios though.
