### PR TITLE
feat(auth): automatically buffer token & user verification requests

### DIFF
--- a/.changeset/giant-dryers-fetch.md
+++ b/.changeset/giant-dryers-fetch.md
@@ -1,0 +1,6 @@
+---
+"@navigraph/auth": patch
+---
+
+Added request buffers to all token requests, including user verification.
+This ensures that the SDK does not send multiple identical token requests in parallel and instead returns one response for all requests, ultimately increasing both speed and reliability.

--- a/packages/auth/src/api/requestToken.ts
+++ b/packages/auth/src/api/requestToken.ts
@@ -2,17 +2,32 @@ import axios from "axios";
 import { getIdentityTokenEndpoint } from "../constants";
 import { NavigraphCancelToken } from "../lib/navigraphRequest";
 import { TokenResponse } from "./types";
-import { AuthenticationAbortedError, Scope } from "@navigraph/app";
+import { AuthenticationAbortedError, Logger, NotInitializedError, Scope, getApp } from "@navigraph/app";
 import { tokenStorage } from "../internals/storage";
 import { setUser } from "../internals/user";
 import { decodeUser } from "../util";
 
+const requests = new Map<string, Promise<TokenResponse> | null>();
+
 /** Requests a token using provided options and updates the credential stores with the result. Also sets the user variable. */
 export async function requestToken(params: Record<string, string>, cancelToken?: NavigraphCancelToken) {
-  return axios
+  const app = getApp();
+  if (!app) throw new NotInitializedError("Auth");
+
+  const key = JSON.stringify(params);
+  const ongoingRequest = requests.get(key);
+
+  if (ongoingRequest) {
+    Logger.debug("Found ongoing request with key " + key);
+    return ongoingRequest;
+  }
+
+  Logger.debug("No ongoing request found with key " + key);
+
+  const requestPromise = axios
     .post<TokenResponse>(getIdentityTokenEndpoint(), new URLSearchParams(params), {
       cancelToken,
-      withCredentials: params.scope?.includes(Scope.TILES) ? true : undefined,
+      withCredentials: app.scopes.includes(Scope.TILES) ? true : undefined,
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
     })
     .then(async ({ data }) => {
@@ -27,5 +42,9 @@ export async function requestToken(params: Record<string, string>, cancelToken?:
       if (axios.isCancel(err)) throw new AuthenticationAbortedError();
 
       throw err;
-    });
+    })
+    .finally(() => requests.delete(key));
+
+  requests.set(key, requestPromise);
+  return requestPromise;
 }


### PR DESCRIPTION

## 📝 Description

When multiple functions create token requests, or when they call `getUser(true)` to verify the currently signed-in user, there is a possibility that multiple token requests fire at the same time. To prevent this, only the first call should create a request, and the following calls should just receive the existing promise directly without creating a separate request.

## ⛳️ Current behavior

Repeated, parallel calls to `requestToken`, even with the same parameters, will result in multiple network requests being made.

## 🚀 New behavior

Only the first call results in a network request, and the following calls receive the existing promise directly without creating a separate request.

## 💣 Is this a breaking change (Yes/No):

No
