### PR TITLE
Include `Promise.finally` polyfill in dist output

### DIFF
--- a/.changeset/few-penguins-move.md
+++ b/.changeset/few-penguins-move.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/auth": patch
+---
+
+Included a polyfill for `Promise.finally` to make the SDK work in MSFS directly out of the box without additional setup.

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "release": "changeset publish"
   },
   "devDependencies": {
-    "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
     "@babel/core": "^7.18.5",
     "@babel/preset-env": "^7.18.2",
     "@babel/preset-typescript": "^7.17.12",
     "@changesets/changelog-github": "^0.4.5",
     "@changesets/cli": "^2.23.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.1.0",
     "@swc/core": "^1.3.11",
     "@types/jest": "^29.2.0",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
@@ -32,6 +32,7 @@
     "eslint": "^8.47.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "finally-polyfill": "^0.2.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.2.2",
     "jest-localstorage-mock": "^2.4.26",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,5 @@
+import "finally-polyfill"
+
 export { CancelToken, navigraphRequest, isAxiosError } from "./lib/navigraphRequest"
 export { default as getAuth, type NavigraphAuth } from "./lib/getAuth"
 export type * from "./flows/device-flow"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from "tsup"
 
 export default defineConfig({
   clean: true,
   format: ["cjs", "esm"],
   target: "es6",
   noExternal: ["axios", "@navigraph/pkce"],
-  outExtension: (ctx) => ({ js: `.${ctx.format}.js` }),
-});
+  outExtension: ctx => ({ js: `.${ctx.format}.js` }),
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6893,6 +6893,11 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
+finally-polyfill@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/finally-polyfill/-/finally-polyfill-0.2.0.tgz#1b34c6e555a6c1603d2ae046e2e176d08687bfdb"
+  integrity sha512-3w46w5Vo4TRtk5jrLT3c8ITGxnPJhMAg3Ogbj4nmgL6thNep9+UgBgk+IRVmRpZDbwNkR7tyGsE3S3J4Qt2zVw==
+
 find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
@@ -14211,10 +14216,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## 📝 Description

This PR fixes an issue where usage of `Promise.finally` within the `@navigraph/auth` package would throw exceptions in MSFS unless the environment was configured with a polyfill.

## ⛳️ Current behavior

Authenticating with the help of the SDK causes a `TypeError` upon request completion.

## 🚀 New behavior

No errors are thrown upon completing the sign-in, and the cleanups that were found in the `finally` section are now run correctly!

## 💣 Is this a breaking change (Yes/No):

No