### PR TITLE
Prevent postinstall from leaking to npm

### DIFF
--- a/.changeset/fluffy-donkeys-beg.md
+++ b/.changeset/fluffy-donkeys-beg.md
@@ -1,0 +1,5 @@
+---
+"@navigraph/weather": patch
+---
+
+Removed package scripts from published NPM package. Most importantly, this prevevents the `postinstall` script (which is only intended to be used during development) from being included.

--- a/packages/weather/clean-package.config.json
+++ b/packages/weather/clean-package.config.json
@@ -11,5 +11,6 @@
       },
       "./package.json": "./package.json"
     }
-  }
+  },
+  "remove": ["scripts"]
 }


### PR DESCRIPTION

Closes #104

## 📝 Description

This PR addresses a valid concern: The `@navigraph/weather` module has a `postinstall` script included when published to NPM. This script is meant to run patch-package on the `metar-taf-parser` package to make sure that it exposes types correctly, but this is only needed during development and should not be part of the installation process for any downstream projects.

## ⛳️ Current behavior

If you use a package manager that runs postinstall scripts by default, `patch-package` is executed when installing the package. Since the package itself is not included, and since there are no patches shipped in the package, the command fails.

## 🚀 New behavior

The postinstall script is removed. Nothing runs upon installation.

## 💣 Is this a breaking change (Yes/No):

No
